### PR TITLE
Make +(sign plus) optional.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@ var Joi = require('joi');
 
 module.exports = {
 	e164 : function () {
-	  return Joi.string().regex(/^\+(?:[0-9] ?){6,14}[0-9]$/);
+	  return Joi.string().regex(/^(\+?)(?:[0-9] ?){6,14}[0-9]$/);
 	}
 }


### PR DESCRIPTION
In accordance with E.164 specification: The presentation of numbers is usually prefixed with the character + (plus sign).
